### PR TITLE
Raised wait_for_update to 2000ms

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -163,7 +163,7 @@ ___TEMPLATE_PARAMETERS___
         "simpleValueType": true,
         "valueUnit": "miliseconds",
         "help": "Set how many miliseconds to wait before firing tags waiting for consent",
-        "defaultValue": 500,
+        "defaultValue": 2000,
         "valueValidators": [
           {
             "type": "NON_EMPTY"


### PR DESCRIPTION
It seems that 500ms is not enough to reliably ensure that
consent have been signaled before other tags are fired.
* Set default wait_for_update value to 2000