### PR TITLE
Implement updateConsentState and gtagSet API's

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -224,6 +224,7 @@ const urlPassthrough = data.urlPassthrough;
 const adsDataRedaction = data.adsDataRedaction;
 
 let scriptUrl = 'https://consent.cookiebot.com/uc.js?cbid=' + encodeUriComponent(cookiebotSerial);
+scriptUrl += '&consentmode-dataredaction=' + adsDataRedaction;
 
 if (language === 'variable')
 {


### PR DESCRIPTION
Added support for ads_data_redaction and url_passthrough, and implemented "updateConsentState" and gtagSet API's